### PR TITLE
Add authentication controller

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    /**
+     * Handle an authentication attempt and return a Sanctum token.
+     */
+    public function login(Request $request)
+    {
+        $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+            'device_name' => 'required|string',
+        ]);
+
+        $user = User::where('email', $request->email)->first();
+
+        if (! $user || ! Hash::check($request->password, $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => ['The provided credentials do not match our records.'],
+            ]);
+        }
+
+        return response()->json([
+            'token' => $user->createToken($request->device_name)->plainTextToken,
+            'user' => $user,
+        ]);
+    }
+
+    /**
+     * Register a new user and return a Sanctum token.
+     */
+    public function register(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|confirmed|min:8',
+            'device_name' => 'required|string',
+        ]);
+
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => Hash::make($request->password),
+            'role' => User::ROLE_USER,
+        ]);
+
+        return response()->json([
+            'token' => $user->createToken($request->device_name)->plainTextToken,
+            'user' => $user,
+        ], 201);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,14 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Laravel\Sanctum\HasApiTokens; // We'll add this back when doing auth
+use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Database\Eloquent\Relations\HasMany; // Import HasMany
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable; // Temporarily just HasFactory, Notifiable
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
 
     public const ROLE_ADMIN = 'admin';

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\UserFavoriteController;
 use App\Http\Controllers\Api\RestaurantController;
 use App\Http\Controllers\Api\OrderController;
 use App\Http\Controllers\Api\ProductReviewController;
+use App\Http\Controllers\Api\AuthController;
 
 // Test route
 Route::get('/ping', function () {
@@ -16,26 +17,8 @@ Route::get('/ping', function () {
 });
 
 // Public routes (no authentication required)
-Route::post('/login', function (Request $request) {
-    $request->validate([
-        'email' => 'required|email',
-        'password' => 'required',
-        'device_name' => 'required|string',
-    ]);
-    
-    $user = \App\Models\User::where('email', $request->email)->first();
-    
-    if (! $user || ! \Illuminate\Support\Facades\Hash::check($request->password, $user->password)) {
-        throw \Illuminate\Validation\ValidationException::withMessages([
-            'email' => ['The provided credentials do not match our records.'],
-        ]);
-    }
-    
-    return response()->json([
-        'token' => $user->createToken($request->device_name)->plainTextToken,
-        'user' => $user
-    ]);
-});
+Route::post('/login', [AuthController::class, 'login']);
+Route::post('/register', [AuthController::class, 'register']);
 
 // Public API routes (if you want them accessible without auth)
 Route::apiResource('categories', CategoryController::class);


### PR DESCRIPTION
## Summary
- add `AuthController` for login and registration
- return Sanctum tokens on login and register
- route `/login` and `/register` through `AuthController`
- enable `HasApiTokens` trait for `User`

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433316fc4c833089f504f3ea0f3fe7