### PR TITLE
Enable Sanctum protection across API controllers

### DIFF
--- a/app/Http/Controllers/Api/CategoryController.php
+++ b/app/Http/Controllers/Api/CategoryController.php
@@ -12,6 +12,11 @@ use Illuminate\Http\Response; // For HTTP status codes
 
 class CategoryController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum')->except(['index', 'show']);
+    }
+
     /**
      * Display a listing of the resource.
      * Corresponds to: GET api/categories (GetCategories in .NET)

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -17,8 +17,7 @@ class OrderController extends Controller
 {
     public function __construct()
     {
-        // Most order actions should be protected
-        // $this->middleware('auth:sanctum'); // Add when Sanctum is ready
+        $this->middleware('auth:sanctum');
     }
 
     /**
@@ -28,9 +27,9 @@ class OrderController extends Controller
     public function index(Request $request)
     {
         $user = Auth::user();
-        // Temporary for testing without full auth
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); }
-        if (!$user) { return response()->json(['message' => 'User not found for listing orders.'], 404); }
+        if (!$user) {
+            return response()->json(['message' => 'User not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
 
         $orders = $user->orders() // Assuming 'orders' relationship exists on User model
                        ->with(['shippingAddress', 'billingAddress', 'orderItems.product']) // Eager load details
@@ -47,9 +46,9 @@ class OrderController extends Controller
     public function store(CreateOrderRequest $request)
     {
         $user = Auth::user();
-        // Temporary for testing without full auth
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); }
-        if (!$user) { return response()->json(['message' => 'User not found to create order.'], 400); }
+        if (!$user) {
+            return response()->json(['message' => 'User not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
 
         $validatedData = $request->validated();
         $orderItemsData = $validatedData['items'];

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -12,6 +12,11 @@ use Illuminate\Http\Response;
 
 class ProductController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum')->except(['index', 'show']);
+    }
+
     /**
      * Display a listing of the resource.
      * GET /api/products

--- a/app/Http/Controllers/Api/ProductReviewController.php
+++ b/app/Http/Controllers/Api/ProductReviewController.php
@@ -15,7 +15,7 @@ class ProductReviewController extends Controller
 {
     public function __construct()
     {
-        // $this->middleware('auth:sanctum')->except(['index']); // Example: listing reviews is public
+        $this->middleware('auth:sanctum')->except(['index']);
     }
 
     /**
@@ -35,9 +35,9 @@ class ProductReviewController extends Controller
     public function store(CreateReviewRequest $request, Product $product)
     {
         $user = Auth::user();
-        // Temporary for testing without full auth
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); }
-        if (!$user) { return response()->json(['message' => 'User not found to create review.'], 400); }
+        if (!$user) {
+            return response()->json(['message' => 'User not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
 
         // Check if user already reviewed this product (optional business rule)
         // if ($product->reviews()->where('UserId', $user->id)->exists()) {

--- a/app/Http/Controllers/Api/RestaurantController.php
+++ b/app/Http/Controllers/Api/RestaurantController.php
@@ -13,6 +13,12 @@ use Illuminate\Http\Response;
 
 class RestaurantController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum')
+            ->except(['index', 'show', 'getRestaurantCategories', 'getRestaurantProducts']);
+    }
+
     /**
      * Display a listing of the resource.
      * GET /api/restaurants

--- a/app/Http/Controllers/Api/UserFavoriteController.php
+++ b/app/Http/Controllers/Api/UserFavoriteController.php
@@ -12,8 +12,7 @@ class UserFavoriteController extends Controller
 {
     public function __construct()
     {
-        // All actions here require an authenticated user
-        // $this->middleware('auth:sanctum'); // Add when Sanctum is ready
+        $this->middleware('auth:sanctum');
     }
 
     /**
@@ -23,9 +22,9 @@ class UserFavoriteController extends Controller
     public function index()
     {
         $user = Auth::user();
-        // If testing without auth:
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); } // Temporary
-        if (!$user) { return response()->json(['message' => 'User not found for favorites list.'], 404); }
+        if (!$user) {
+            return response()->json(['message' => 'User not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
 
 
         // Eager load what ProductResource might need (category, restaurant)
@@ -40,9 +39,9 @@ class UserFavoriteController extends Controller
     public function store(Request $request, Product $product) // Product via route-model binding
     {
         $user = Auth::user();
-        // If testing without auth:
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); } // Temporary
-        if (!$user) { return response()->json(['message' => 'User not found to add favorite.'], 404); }
+        if (!$user) {
+            return response()->json(['message' => 'User not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
 
         // Attach if not already attached. syncWithoutDetaching adds if not present.
         // The second argument to attach/sync is for extra pivot data.
@@ -58,9 +57,9 @@ class UserFavoriteController extends Controller
     public function destroy(Request $request, Product $product) // Product via route-model binding
     {
         $user = Auth::user();
-        // If testing without auth:
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); } // Temporary
-        if (!$user) { return response()->json(['message' => 'User not found to remove favorite.'], 404); }
+        if (!$user) {
+            return response()->json(['message' => 'User not authenticated.'], Response::HTTP_UNAUTHORIZED);
+        }
 
         $user->favoriteProducts()->detach($product->Id);
 

--- a/app/Http/Requests/CreateAddressRequest.php
+++ b/app/Http/Requests/CreateAddressRequest.php
@@ -1,13 +1,13 @@
 <?php
 namespace App\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 
 class CreateAddressRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        // Will require authenticated user later
-        return true; // Placeholder
+        return Auth::check();
     }
 
     public function rules(): array

--- a/app/Http/Requests/CreateCategoryRequest.php
+++ b/app/Http/Requests/CreateCategoryRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 
 class CreateCategoryRequest extends FormRequest
 {
@@ -11,7 +12,7 @@ class CreateCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return Auth::check();
     }
 
     /**

--- a/app/Http/Requests/CreateOrderRequest.php
+++ b/app/Http/Requests/CreateOrderRequest.php
@@ -13,9 +13,7 @@ class CreateOrderRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        // Only authenticated users can create orders.
-        // return Auth::check(); // Enable this once Sanctum auth is fully working
-        return true; // Placeholder for now until auth is fully set up
+        return Auth::check();
     }
 
     /**

--- a/app/Http/Requests/CreateRestaurantRequest.php
+++ b/app/Http/Requests/CreateRestaurantRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
-use App\Models\User; // If you want to use User model for authorization
+use Illuminate\Support\Facades\Auth;
 
 class CreateRestaurantRequest extends FormRequest
 {
@@ -13,12 +13,7 @@ class CreateRestaurantRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        // Placeholder: For now, allow anyone.
-        // Replace with actual authorization logic when auth is set up.
-        // Example:
-        // $user = $this->user(); // Gets the authenticated user via Sanctum
-        // return $user && $user->isAdmin();
-        return true;
+        return Auth::check();
     }
 
     /**

--- a/app/Http/Requests/CreateReviewRequest.php
+++ b/app/Http/Requests/CreateReviewRequest.php
@@ -7,8 +7,7 @@ class CreateReviewRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        // return Auth::check(); // User must be logged in
-        return true; // Placeholder until Sanctum auth is fully implemented
+        return Auth::check();
     }
 
     public function rules(): array

--- a/app/Http/Requests/UpdateAddressRequest.php
+++ b/app/Http/Requests/UpdateAddressRequest.php
@@ -1,13 +1,13 @@
 <?php
 namespace App\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 
 class UpdateAddressRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        // Will require user to own the address or be admin
-        return true; // Placeholder
+        return Auth::check();
     }
 
     public function rules(): array

--- a/app/Http/Requests/UpdateCategoryRequest.php
+++ b/app/Http/Requests/UpdateCategoryRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class UpdateCategoryRequest extends FormRequest
 {
@@ -11,7 +13,7 @@ class UpdateCategoryRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return Auth::check();
     }
 
     /**

--- a/app/Http/Requests/UpdateRestaurantRequest.php
+++ b/app/Http/Requests/UpdateRestaurantRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule; // For more complex rules like unique ignoring current model
 
 class UpdateRestaurantRequest extends FormRequest
@@ -12,12 +13,7 @@ class UpdateRestaurantRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        // Placeholder: For now, allow anyone.
-        // Replace with actual authorization logic.
-        // Example:
-        // $user = $this->user();
-        // return $user && $user->isAdmin();
-        return true;
+        return Auth::check();
     }
 
     /**

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,18 +2,25 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
     /**
      * A basic test example.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    public function test_authenticated_user_endpoint_returns_user_info(): void
     {
-        $response = $this->get('/');
+        $user = User::factory()->create();
+        $token = $user->createToken('test')->plainTextToken;
 
-        $response->assertStatus(200);
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->getJson('/api/user');
+
+        $response->assertStatus(200)
+            ->assertJson(['id' => $user->id]);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- protect all API controllers with `auth:sanctum`
- remove fallback `user@example.com` logic
- require auth in request classes
- add Sanctum token table migration
- update feature test to use Sanctum token

## Testing
- `composer test`
- `./vendor/bin/phpunit --display-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68433317c0dc8330bb7968036ea00c0e