### PR TITLE
Add Apartment column support

### DIFF
--- a/app/Http/Requests/CreateAddressRequest.php
+++ b/app/Http/Requests/CreateAddressRequest.php
@@ -14,6 +14,7 @@ class CreateAddressRequest extends FormRequest
     {
         return [
             'Street' => 'required|string|max:100',
+            'Apartment' => 'nullable|string|max:50',
             'City' => 'required|string|max:50',
             'PostalCode' => 'required|string|max:20',
             'Country' => 'required|string|max:50',

--- a/app/Http/Requests/UpdateAddressRequest.php
+++ b/app/Http/Requests/UpdateAddressRequest.php
@@ -14,6 +14,7 @@ class UpdateAddressRequest extends FormRequest
     {
         return [
             'Street' => 'sometimes|required|string|max:100',
+            'Apartment' => 'sometimes|nullable|string|max:50',
             'City' => 'sometimes|required|string|max:50',
             'PostalCode' => 'sometimes|required|string|max:20',
             'Country' => 'sometimes|required|string|max:50',

--- a/app/Http/Resources/AddressResource.php
+++ b/app/Http/Resources/AddressResource.php
@@ -10,6 +10,7 @@ class AddressResource extends JsonResource
         return [
             'Id' => $this->Id,
             'Street' => $this->Street,
+            'Apartment' => $this->Apartment,
             'City' => $this->City,
             'PostalCode' => $this->PostalCode,
             'Country' => $this->Country,

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -35,6 +35,7 @@ class Address extends Model
      */
     protected $fillable = [
         'Street',
+        'Apartment',
         'City',
         'PostalCode',
         'Country',

--- a/database/migrations/2025_06_02_192001_create_addresses_table.php
+++ b/database/migrations/2025_06_02_192001_create_addresses_table.php
@@ -11,6 +11,7 @@ return new class extends Migration
         Schema::create('Addresses', function (Blueprint $table) { // Your table name 'Addresses' is fine
             $table->id('Id'); // Your primary key 'Id' for this table is fine
             $table->string('Street', 100);
+            $table->string('Apartment')->nullable();
             $table->string('City', 50);
             $table->string('PostalCode', 20);
             $table->string('Country', 50);

--- a/database/migrations/2025_06_04_000000_add_apartment_to_addresses_table.php
+++ b/database/migrations/2025_06_04_000000_add_apartment_to_addresses_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('Addresses', function (Blueprint $table) {
+            if (!Schema::hasColumn('Addresses', 'Apartment')) {
+                $table->string('Apartment')->nullable()->after('Street');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('Addresses', function (Blueprint $table) {
+            if (Schema::hasColumn('Addresses', 'Apartment')) {
+                $table->dropColumn('Apartment');
+            }
+        });
+    }
+};
+

--- a/database/seeders/AddressSeeder.php
+++ b/database/seeders/AddressSeeder.php
@@ -14,6 +14,7 @@ class AddressSeeder extends Seeder
         if ($user) { // Check if user was found
             Address::create([
                 'Street' => '123 Main St',
+                'Apartment' => 'Apt 1',
                 'City' => 'Anytown',
                 'PostalCode' => '12345',
                 'Country' => 'USA',
@@ -21,6 +22,7 @@ class AddressSeeder extends Seeder
             ]);
             Address::create([
                 'Street' => '456 Oak Ave',
+                'Apartment' => 'Suite 200',
                 'City' => 'Otherville',
                 'PostalCode' => '67890',
                 'Country' => 'USA',


### PR DESCRIPTION
## Summary
- allow Addresses to store Apartment numbers
- include Apartment field in API requests and resources
- seed Apartment sample data

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68433318af908330afac1706965c005a