### PR TITLE
Add payment and order item APIs

### DIFF
--- a/app/Http/Controllers/Api/OrderItemController.php
+++ b/app/Http/Controllers/Api/OrderItemController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\OrderItem;
+use App\Http\Resources\OrderItemResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class OrderItemController extends Controller
+{
+    /**
+     * Display a listing of order items.
+     */
+    public function index()
+    {
+        $items = OrderItem::with(['order', 'product'])->paginate(15);
+        return OrderItemResource::collection($items);
+    }
+
+    /**
+     * Store a newly created order item in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'OrderId' => 'required|exists:Orders,Id',
+            'ProductId' => 'required|exists:Products,Id',
+            'Quantity' => 'required|integer|min:1',
+            'UnitPrice' => 'required|numeric',
+        ]);
+
+        $item = OrderItem::create($validated);
+        $item->load(['order', 'product']);
+
+        return (new OrderItemResource($item))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    /**
+     * Display the specified order item.
+     */
+    public function show(OrderItem $orderItem)
+    {
+        $orderItem->load(['order', 'product']);
+        return new OrderItemResource($orderItem);
+    }
+
+    /**
+     * Update the specified order item in storage.
+     */
+    public function update(Request $request, OrderItem $orderItem)
+    {
+        $validated = $request->validate([
+            'OrderId' => 'sometimes|exists:Orders,Id',
+            'ProductId' => 'sometimes|exists:Products,Id',
+            'Quantity' => 'sometimes|integer|min:1',
+            'UnitPrice' => 'sometimes|numeric',
+        ]);
+
+        $orderItem->update($validated);
+        $orderItem->load(['order', 'product']);
+
+        return new OrderItemResource($orderItem);
+    }
+
+    /**
+     * Remove the specified order item from storage.
+     */
+    public function destroy(OrderItem $orderItem)
+    {
+        $orderItem->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Payment;
+use App\Http\Resources\PaymentResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class PaymentController extends Controller
+{
+    /**
+     * Display a listing of the payments.
+     */
+    public function index()
+    {
+        $payments = Payment::with('order')->paginate(15);
+        return PaymentResource::collection($payments);
+    }
+
+    /**
+     * Store a newly created payment in storage.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'OrderId' => 'required|exists:Orders,Id',
+            'PaymentDate' => 'sometimes|date',
+            'Amount' => 'required|numeric',
+            'PaymentMethod' => 'required|string|max:50',
+            'TransactionId' => 'nullable|string|max:100',
+            'Status' => 'required|string|in:' . implode(',', [
+                Payment::STATUS_PENDING,
+                Payment::STATUS_SUCCEEDED,
+                Payment::STATUS_FAILED,
+                Payment::STATUS_REFUNDED,
+            ]),
+        ]);
+
+        $payment = Payment::create($validated);
+        $payment->load('order');
+
+        return (new PaymentResource($payment))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    /**
+     * Display the specified payment.
+     */
+    public function show(Payment $payment)
+    {
+        $payment->load('order');
+        return new PaymentResource($payment);
+    }
+
+    /**
+     * Update the specified payment in storage.
+     */
+    public function update(Request $request, Payment $payment)
+    {
+        $validated = $request->validate([
+            'OrderId' => 'sometimes|exists:Orders,Id',
+            'PaymentDate' => 'sometimes|date',
+            'Amount' => 'sometimes|numeric',
+            'PaymentMethod' => 'sometimes|string|max:50',
+            'TransactionId' => 'nullable|string|max:100',
+            'Status' => 'sometimes|string|in:' . implode(',', [
+                Payment::STATUS_PENDING,
+                Payment::STATUS_SUCCEEDED,
+                Payment::STATUS_FAILED,
+                Payment::STATUS_REFUNDED,
+            ]),
+        ]);
+
+        $payment->update($validated);
+        $payment->load('order');
+
+        return new PaymentResource($payment);
+    }
+
+    /**
+     * Remove the specified payment from storage.
+     */
+    public function destroy(Payment $payment)
+    {
+        $payment->delete();
+        return response()->noContent();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,8 @@ use App\Http\Controllers\Api\UserFavoriteController;
 use App\Http\Controllers\Api\RestaurantController;
 use App\Http\Controllers\Api\OrderController;
 use App\Http\Controllers\Api\ProductReviewController;
+use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\OrderItemController;
 
 // Test route
 Route::get('/ping', function () {
@@ -59,6 +61,8 @@ Route::middleware('auth:sanctum')->group(function () {
     // User-specific resources
     Route::apiResource('addresses', AddressController::class);
     Route::apiResource('orders', OrderController::class);
+    Route::apiResource('payments', PaymentController::class);
+    Route::apiResource('order-items', OrderItemController::class);
     
     // Favorites
     Route::get('/favorites', [UserFavoriteController::class, 'index'])->name('favorites.index');


### PR DESCRIPTION
## Summary
- add `PaymentController` and `OrderItemController` with CRUD endpoints
- register routes for new resources
- run phpunit tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684333192364833094e62bd76938a074