### PR TITLE
Add auth middleware and tests

### DIFF
--- a/app/Http/Controllers/Api/AddressController.php
+++ b/app/Http/Controllers/Api/AddressController.php
@@ -9,48 +9,24 @@ use App\Http\Requests\UpdateAddressRequest;
 use App\Http\Resources\AddressResource;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-// REMOVE THIS LINE: use Illuminate\Foundation\Configuration\Middleware;
-use Illuminate\Support\Facades\Auth; // Keep this for Auth::user()
 
 class AddressController extends Controller
 {
     public function __construct()
     {
-        // Now this should work
-        $this->middleware('auth:sanctum')->except(['index', 'show']);
+        $this->middleware('auth:sanctum');
     }
 
     public function index(Request $request)
     {
-        // If we have auth:
-        // $user = Auth::user(); // Or $request->user() if middleware is applied
-        // if ($user) {
-        //     $addresses = $user->addresses()->get();
-        //     return AddressResource::collection($addresses);
-        // }
-
-        // Temporary: For testing without full auth, allow fetching all or by userId param
-        // Since 'index' is excepted from 'auth:sanctum', Auth::user() might be null here
-        // unless a token is optionally provided.
-        if ($request->has('userId')) {
-             $addresses = Address::where('UserId', $request->input('userId'))->get();
-        } else {
-            // INSECURE - LISTS ALL ADDRESSES. FOR TESTING ONLY.
-            $addresses = Address::with('user')->get(); // Eager load user for context
-        }
+        $user = $request->user();
+        $addresses = $user->addresses()->get();
         return AddressResource::collection($addresses);
     }
 
     public function store(CreateAddressRequest $request)
     {
-        $user = Auth::user();
-        // $user = Auth::user(); // Also works
-
-        if (!$user) {
-            // This case should ideally not be hit if 'auth:sanctum' middleware is active for store
-            // and a valid token is not provided. The middleware would deny access first.
-            return response()->json(['message' => "User not authenticated."], Response::HTTP_UNAUTHORIZED);
-        }
+        $user = $request->user();
         $address = $user->addresses()->create($request->validated());
 
         return (new AddressResource($address))
@@ -58,27 +34,33 @@ class AddressController extends Controller
                 ->setStatusCode(Response::HTTP_CREATED);
     }
 
-    public function show(Address $address)
+    public function show(Request $request, Address $address)
     {
-        // TODO: Authorization - user can only see their own address or admin can see any
-        // $this->authorize('view', $address); // Requires a Policy
+        $user = $request->user();
+        if ($address->UserId !== $user->id) {
+            return response()->json(['message' => 'Forbidden'], Response::HTTP_FORBIDDEN);
+        }
         $address->load('user');
         return new AddressResource($address);
     }
 
     public function update(UpdateAddressRequest $request, Address $address)
     {
-        // TODO: Authorization
-        // $this->authorize('update', $address);
+        $user = $request->user();
+        if ($address->UserId !== $user->id) {
+            return response()->json(['message' => 'Forbidden'], Response::HTTP_FORBIDDEN);
+        }
         $address->update($request->validated());
         $address->load('user');
         return new AddressResource($address);
     }
 
-    public function destroy(Address $address)
+    public function destroy(Request $request, Address $address)
     {
-        // TODO: Authorization
-        // $this->authorize('delete', $address);
+        $user = $request->user();
+        if ($address->UserId !== $user->id) {
+            return response()->json(['message' => 'Forbidden'], Response::HTTP_FORBIDDEN);
+        }
         $address->delete();
         return response()->noContent();
     }

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -17,8 +17,7 @@ class OrderController extends Controller
 {
     public function __construct()
     {
-        // Most order actions should be protected
-        // $this->middleware('auth:sanctum'); // Add when Sanctum is ready
+        $this->middleware('auth:sanctum');
     }
 
     /**
@@ -27,10 +26,7 @@ class OrderController extends Controller
      */
     public function index(Request $request)
     {
-        $user = Auth::user();
-        // Temporary for testing without full auth
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); }
-        if (!$user) { return response()->json(['message' => 'User not found for listing orders.'], 404); }
+        $user = $request->user();
 
         $orders = $user->orders() // Assuming 'orders' relationship exists on User model
                        ->with(['shippingAddress', 'billingAddress', 'orderItems.product']) // Eager load details
@@ -46,10 +42,7 @@ class OrderController extends Controller
      */
     public function store(CreateOrderRequest $request)
     {
-        $user = Auth::user();
-        // Temporary for testing without full auth
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); }
-        if (!$user) { return response()->json(['message' => 'User not found to create order.'], 400); }
+        $user = $request->user();
 
         $validatedData = $request->validated();
         $orderItemsData = $validatedData['items'];

--- a/app/Http/Controllers/Api/OrderItemController.php
+++ b/app/Http/Controllers/Api/OrderItemController.php
@@ -10,6 +10,10 @@ use Illuminate\Http\Response;
 
 class OrderItemController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum');
+    }
     /**
      * Display a listing of order items.
      */

--- a/app/Http/Controllers/Api/PaymentController.php
+++ b/app/Http/Controllers/Api/PaymentController.php
@@ -10,6 +10,10 @@ use Illuminate\Http\Response;
 
 class PaymentController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum');
+    }
     /**
      * Display a listing of the payments.
      */

--- a/app/Http/Controllers/Api/ProductReviewController.php
+++ b/app/Http/Controllers/Api/ProductReviewController.php
@@ -15,7 +15,7 @@ class ProductReviewController extends Controller
 {
     public function __construct()
     {
-        // $this->middleware('auth:sanctum')->except(['index']); // Example: listing reviews is public
+        $this->middleware('auth:sanctum')->only(['store']);
     }
 
     /**
@@ -34,10 +34,7 @@ class ProductReviewController extends Controller
      */
     public function store(CreateReviewRequest $request, Product $product)
     {
-        $user = Auth::user();
-        // Temporary for testing without full auth
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); }
-        if (!$user) { return response()->json(['message' => 'User not found to create review.'], 400); }
+        $user = $request->user();
 
         // Check if user already reviewed this product (optional business rule)
         // if ($product->reviews()->where('UserId', $user->id)->exists()) {

--- a/app/Http/Controllers/Api/UserFavoriteController.php
+++ b/app/Http/Controllers/Api/UserFavoriteController.php
@@ -12,20 +12,16 @@ class UserFavoriteController extends Controller
 {
     public function __construct()
     {
-        // All actions here require an authenticated user
-        // $this->middleware('auth:sanctum'); // Add when Sanctum is ready
+        $this->middleware('auth:sanctum');
     }
 
     /**
      * List the authenticated user's favorite products.
      * GET /api/favorites
      */
-    public function index()
+    public function index(Request $request)
     {
-        $user = Auth::user();
-        // If testing without auth:
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); } // Temporary
-        if (!$user) { return response()->json(['message' => 'User not found for favorites list.'], 404); }
+        $user = $request->user();
 
 
         // Eager load what ProductResource might need (category, restaurant)
@@ -37,12 +33,9 @@ class UserFavoriteController extends Controller
      * Add a product to the authenticated user's favorites.
      * POST /api/products/{product}/favorite
      */
-    public function store(Request $request, Product $product) // Product via route-model binding
+    public function store(Request $request, Product $product)
     {
-        $user = Auth::user();
-        // If testing without auth:
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); } // Temporary
-        if (!$user) { return response()->json(['message' => 'User not found to add favorite.'], 404); }
+        $user = $request->user();
 
         // Attach if not already attached. syncWithoutDetaching adds if not present.
         // The second argument to attach/sync is for extra pivot data.
@@ -55,12 +48,9 @@ class UserFavoriteController extends Controller
      * Remove a product from the authenticated user's favorites.
      * DELETE /api/products/{product}/unfavorite  (or /api/favorites/{product})
      */
-    public function destroy(Request $request, Product $product) // Product via route-model binding
+    public function destroy(Request $request, Product $product)
     {
-        $user = Auth::user();
-        // If testing without auth:
-        if (!$user) { $user = \App\Models\User::where('email', 'user@example.com')->first(); } // Temporary
-        if (!$user) { return response()->json(['message' => 'User not found to remove favorite.'], 404); }
+        $user = $request->user();
 
         $user->favoriteProducts()->detach($product->Id);
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/tests/Feature/ApiEndpointsTest.php
+++ b/tests/Feature/ApiEndpointsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use Tests\TestCase;
+
+class ApiEndpointsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ping_returns_json(): void
+    {
+        $response = $this->getJson('/api/ping');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure(['message', 'timestamp']);
+    }
+
+    public function test_login_with_invalid_credentials_returns_422(): void
+    {
+        User::factory()->create(['email' => 'john@example.com']);
+
+        $payload = [
+            'email' => 'john@example.com',
+            'password' => 'wrong-password',
+            'device_name' => 'phpunit',
+        ];
+
+        $response = $this->postJson('/api/login', $payload);
+
+        $response->assertStatus(422)
+                 ->assertJsonStructure(['message', 'errors']);
+    }
+}

--- a/tests/Feature/AuthMiddlewareTest.php
+++ b/tests/Feature/AuthMiddlewareTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AuthMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_protected_routes_require_authentication(): void
+    {
+        $response = $this->getJson('/api/addresses');
+        $response->assertStatus(401);
+    }
+
+    public function test_accessing_protected_route_with_token_succeeds(): void
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user, ['*']);
+
+        $response = $this->getJson('/api/addresses');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- enforce `auth:sanctum` on API controllers
- remove temporary user fallbacks
- restrict address routes to owner
- add tests covering auth protection

## Testing
- `composer install`
- `php artisan key:generate`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_684331189cf483309872e337b9a3a248