### PR TITLE
Fix address show strict comparison

### DIFF
--- a/app/Http/Controllers/Api/AddressController.php
+++ b/app/Http/Controllers/Api/AddressController.php
@@ -37,7 +37,7 @@ class AddressController extends Controller
     public function show(Request $request, Address $address)
     {
         $user = $request->user();
-        if ($address->UserId !== $user->id) {
+        if ((int) $address->UserId !== (int) $user->id) {
             return response()->json(['message' => 'Forbidden'], Response::HTTP_FORBIDDEN);
         }
         $address->load('user');
@@ -47,7 +47,7 @@ class AddressController extends Controller
     public function update(UpdateAddressRequest $request, Address $address)
     {
         $user = $request->user();
-        if ($address->UserId !== $user->id) {
+        if ((int) $address->UserId !== (int) $user->id) {
             return response()->json(['message' => 'Forbidden'], Response::HTTP_FORBIDDEN);
         }
         $address->update($request->validated());
@@ -58,7 +58,7 @@ class AddressController extends Controller
     public function destroy(Request $request, Address $address)
     {
         $user = $request->user();
-        if ($address->UserId !== $user->id) {
+        if ((int) $address->UserId !== (int) $user->id) {
             return response()->json(['message' => 'Forbidden'], Response::HTTP_FORBIDDEN);
         }
         $address->delete();


### PR DESCRIPTION
## Summary
- ensure AddressController compares numeric IDs using integers

## Testing
- `vendor/bin/phpunit --filter AllEndpointsTest tests/Feature/AllEndpointsTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68434f88bb088330957658e95916a272